### PR TITLE
Remove duplicate keywords without TR characters

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta name="description" content="Uzaktan çalışmak ile ilgili bilinmesi gereken her şey">
-<meta name="keywords" content="remote calismak, remote çalışmak, türkiyede remote çalışmak, remote çalışmanın avantajları, remote çalışmanın zorlukları, remote iş bulmak, remote iş bulunacak yerler, uzaktan calismak, uzaktan çalışmak, türkiyede uzaktan çalışmak, uzaktan çalışmanın avantajları, uzaktan çalışmanın zorlukları, uzaktan çalışılacak iş bulmak, uzaktan çalışmak için iş bulunacak yerler">
+<meta name="keywords" content="remote çalışmak, türkiye'de remote çalışmak, remote çalışmanın avantajları, remote çalışmanın zorlukları, remote iş bulmak, remote iş bulunacak yerler, uzaktan çalışmak, türkiye'de uzaktan çalışmak, uzaktan çalışmanın avantajları, uzaktan çalışmanın zorlukları, uzaktan çalışılacak iş bulmak, uzaktan çalışmak için iş bulunacak yerler">
 <meta name="author" content="Fatih Acet">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/bootstrap.min.css" />


### PR DESCRIPTION
Türkçe karakter olan ve olmayan keyword'leri bir arada bulundurmaya gerek yok, Google ikisini de anlayabiliyor.

Bu arada tavsiyem keywords tag'ini tamamen kaldırmak yönünde olur. keywords tag'i çok eskilerde kaldı, hatta Bing gibi arama motorları spam sinyali olarak bile değerlendirebiliyor.